### PR TITLE
fix(auth): corrigir fluxo de alteração de senha com reautenticação

### DIFF
--- a/src/app/pages/perfil/perfil.page.ts
+++ b/src/app/pages/perfil/perfil.page.ts
@@ -14,6 +14,7 @@ export class PerfilPage implements OnInit {
   nome: string = '';
   fotoURL: string = '';
   novaSenha: string = '';
+  senhaAtual: string = '';
 
   constructor(
     private perfilService: PerfilService, 
@@ -76,6 +77,7 @@ export class PerfilPage implements OnInit {
                   toast.present();
                   this.novaSenha = '';
                 } catch (err) {
+                  console.error('Error ao alterar senha: ', err)
                   const toast = await this.toastCtrl.create({
                     message: 'Erro ao alterar senha: ' + (err instanceof Error ? err.message : String(err)),
                     duration: 3000,
@@ -86,7 +88,10 @@ export class PerfilPage implements OnInit {
               }
             }
           ]
-        })
+        });
+
+        await alert.present();
+
       } else {
         const toast = await this.toastCtrl.create({
           message: 'Perfil atualizado!',


### PR DESCRIPTION
## O que foi feito:

- Corrigido fluxo de alteração de senha solicitando reautenticação do usuário via modal.
- Removido método `alterarSenha()` do AuthService (não estava sendo utilizado).
- Dependência de testes em ambiente Android (Capacitor) para validar alteração de senha fora do ambiente localhost.

## Próximos passos:

- Configurar ambiente Android via Capacitor.
- Testar alteração de senha em dispositivo físico/emulador para verificar se o problema de `auth/network-request-failed` foi resolvido.

## Checklist:
- [x] Código refatorado e funcionando no fluxo principal.
- [x] Correção de nomenclatura e métodos redundantes.
- [ ] Testes em dispositivo real para confirmar funcionalidade.
